### PR TITLE
Corregir administración de almacenes para Neon

### DIFF
--- a/app.py
+++ b/app.py
@@ -353,15 +353,15 @@ def admin():
         elif form_type == 'add_wh':
             whscode  = request.form.get('whscode')
             cardcode = request.form.get('cardcode')
-            name     = request.form.get('name')
+            whsdesc  = request.form.get('whsdesc')
             cur.execute(
                 """
-                INSERT INTO warehouses (whscode, cardcode, name)
+                INSERT INTO warehouses (whscode, cardcode, whsdesc)
                 VALUES (%s, %s, %s)
                 ON CONFLICT (whscode) DO UPDATE
-                SET cardcode=EXCLUDED.cardcode, name=EXCLUDED.name
+                SET cardcode=EXCLUDED.cardcode, whsdesc=EXCLUDED.whsdesc
                 """,
-                (whscode, cardcode, name)
+                (whscode, cardcode, whsdesc)
             )
             conn.commit()
         elif form_type == 'delete_wh':
@@ -376,7 +376,7 @@ def admin():
         cur.execute("SELECT whscode FROM user_warehouses WHERE username=%s", (u['username'],))
         whs = cur.fetchall()
         u['warehouses'] = [w['whscode'] for w in whs]
-    cur.execute("SELECT whscode, cardcode, name FROM warehouses ORDER BY whscode")
+    cur.execute("SELECT whscode, cardcode, whsdesc FROM warehouses ORDER BY whscode")
     warehouses = cur.fetchall()
     cur.close(); conn.close()
     return render_template('admin.html', users=users, warehouses=warehouses)

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -72,7 +72,7 @@
     <tr>
       <td>{{ w.whscode }}</td>
       <td>{{ w.cardcode }}</td>
-      <td>{{ w.name }}</td>
+      <td>{{ w.whsdesc }}</td>
       <td>
         <form method="post" style="display:inline;">
           <input type="hidden" name="form_type" value="delete_wh">
@@ -89,7 +89,7 @@
     <input type="hidden" name="form_type" value="add_wh">
     WhsCode: <input type="text" name="whscode" required>
     CardCode: <input type="text" name="cardcode" required>
-    Nombre: <input type="text" name="name" required>
+    Nombre: <input type="text" name="whsdesc" required>
     <button type="submit">Guardar</button>
   </form>
 </body>


### PR DESCRIPTION
## Summary
- Usar columna `whsdesc` al crear y listar almacenes
- Actualizar formulario de administración para el nuevo campo

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68ae38925a188322b303bed5dc899db2