### PR TITLE
feat: improve order history view

### DIFF
--- a/app.py
+++ b/app.py
@@ -262,22 +262,25 @@ def submit():
     # Guardar histórico con selected_whs y cardcode calculado
     data = resp.json()
     conn_h = get_db_connection(); cur_h = conn_h.cursor()
-    cur_h.execute(
-        """
-        INSERT INTO recorded_orders (
-          timestamp, username, whscode, cardcode, docentry, docnum
-        ) VALUES (
-          NOW(), %s, %s, %s, %s, %s
+    for line in lines:
+        cur_h.execute(
+            """
+            INSERT INTO recorded_orders (
+              timestamp, username, whscode, cardcode, docentry, docnum, itemcode, quantity
+            ) VALUES (
+              NOW(), %s, %s, %s, %s, %s, %s, %s
+            )
+            """,
+            (
+                session['username'],
+                selected_whs,
+                cardcode,
+                data.get('DocEntry'),
+                data.get('DocNum'),
+                line['ItemCode'],
+                line['Quantity']
+            )
         )
-        """,
-        (
-            session['username'],
-            selected_whs,
-            cardcode,
-            data.get('DocEntry'),
-            data.get('DocNum')
-        )
-    )
     conn_h.commit(); cur_h.close(); conn_h.close()
     return render_template(
         'result.html',
@@ -290,27 +293,38 @@ def submit():
 def history():
     if 'username' not in session:
         return redirect(url_for('login'))
+    start_date = request.args.get('start_date')
+    end_date = request.args.get('end_date')
+    whscode = request.args.get('whscode')
+    user_filter = request.args.get('username')
     conn = get_db_connection(); cur = conn.cursor()
     allowed = ('manager','admin','supervisor')
+    query = (
+        "SELECT timestamp, username, cardcode, whscode, docnum, itemcode, quantity "
+        "FROM recorded_orders WHERE 1=1"
+    )
+    params = []
     if session.get('role') in allowed:
-        # Ven todo el histórico
-        cur.execute(
-            "SELECT timestamp, username, cardcode, whscode, docnum "
-            "FROM recorded_orders "
-            "ORDER BY timestamp DESC LIMIT 50"
-        )
+        if user_filter:
+            query += " AND username=%s"
+            params.append(user_filter)
     else:
-        # Sólo lo propio
-        cur.execute(
-            "SELECT timestamp, cardcode, whscode, docnum "
-            "FROM recorded_orders "
-            "WHERE username=%s "
-            "ORDER BY timestamp DESC LIMIT 50",
-            (session['username'],)
-        )
-    
+        query += " AND username=%s"
+        params.append(session['username'])
+    if start_date:
+        query += " AND timestamp::date >= %s"
+        params.append(start_date)
+    if end_date:
+        query += " AND timestamp::date <= %s"
+        params.append(end_date)
+    if whscode:
+        query += " AND whscode=%s"
+        params.append(whscode)
+    query += " ORDER BY timestamp DESC LIMIT 100"
+    cur.execute(query, params)
     rows = cur.fetchall(); cur.close(); conn.close()
-    return render_template('history.html', rows=rows)
+    filters = {'start_date': start_date, 'end_date': end_date, 'whscode': whscode, 'username': user_filter}
+    return render_template('history.html', rows=rows, filters=filters, is_admin=session.get('role') in allowed)
 
 @app.route("/admin", methods=["GET", "POST"])
 @roles_required('admin')

--- a/static/css/history.css
+++ b/static/css/history.css
@@ -1,0 +1,70 @@
+body {
+  font-family: 'Montserrat', sans-serif;
+  background: url("../images/fondo.png") no-repeat center/cover fixed;
+  margin: 0;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+h1 {
+  margin-top: 0.5rem;
+}
+
+form.filter {
+  background: rgba(255,255,255,0.85);
+  padding: 1rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  justify-content: center;
+}
+
+form.filter label {
+  display: flex;
+  flex-direction: column;
+  font-weight: bold;
+  font-size: 0.9rem;
+}
+
+form.filter input {
+  padding: 0.25rem;
+  border: 1px solid #ccc;
+  border-radius: 0.375rem;
+}
+
+form.filter button {
+  background-color: #0A2140;
+  color: #fff;
+  border: none;
+  border-radius: 0.375rem;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.table-wrapper {
+  width: 100%;
+  max-width: 900px;
+  overflow-x: auto;
+}
+
+.history-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: rgba(255,255,255,0.9);
+}
+
+.history-table th, .history-table td {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.history-table th {
+  background-color: #0A2140;
+  color: #fff;
+}

--- a/templates/history.html
+++ b/templates/history.html
@@ -1,121 +1,63 @@
 <!DOCTYPE html>
 <html lang="es">
-
 <head>
   <meta charset="utf-8">
   <title>Historial de Órdenes</title>
-
-  <style>
-    /* Variables y tipografía */
-    :root {
-      --font-primary: 'Montserrat', sans-serif;
-    }
-
-    html,
-    body {
-      height: 100%;
-      margin: 0;
-    }
-
-    body {
-      font-family: var(--font-primary);
-      background: url("{{ url_for('static', filename='images/fondo.png') }}") no-repeat center/cover;
-      background-size: 100vw 100vh;
-      background-repeat: no-repeat;
-      background-attachment: fixed;
-      display: flex;
-      flex-direction: column;
-      /*justify-content: center;*/
-      align-items: center;
-      text-align: center;
-      gap: 1.5rem;
-      min-height: 100vh;
-    }
-
-    /* 3) Caja “card” para el login */
-    .login-box {
-      background: rgba(255, 255, 255, 0.85);
-      padding: 2rem;
-      border-radius: 0.5rem;
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-      max-width: 360px;
-      width: 100%;
-    }
-
-    /* 4) Inputs */
-    input[type="text"],
-    input[type="password"] {
-      width: 100%;
-      padding: 0.75rem;
-      margin-top: 0.25rem;
-      border: 1px solid #ccc;
-      border-radius: 0.375rem;
-      font-size: 1rem;
-      transition: border-color 0.2s;
-    }
-
-    input:focus {
-      outline: none;
-      border-color: #0A2140;
-    }
-
-    /* 5) Botón */
-    button {
-      width: 100%;
-      padding: 0.75rem;
-      margin-top: 1rem;
-      background-color: #0A2140;
-      color: #fff;
-      border: none;
-      border-radius: 0.375rem;
-      font-size: 1rem;
-      cursor: pointer;
-      transition: background-color 0.2s;
-    }
-
-    button:hover {
-      background-color: #0A2140;
-    }
-
-    /* 6) Responsivo */
-    @media (max-width: 400px) {
-      .login-box {
-        padding: 1rem;
-      }
-
-      h1 {
-        font-size: 1.5rem;
-      }
-    }
-  </style>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/history.css') }}">
 </head>
-
 <body>
-  <h1></h1>
   <h1>Historial de Órdenes</h1>
   <p><a href="{{ url_for('dashboard') }}">← Volver al Dashboard</a></p>
-  <table border="1" cellpadding="4">
-    <tr>
-      <th>Fecha / Hora</th>
-      <th>Cliente (CardCode)</th>
-      <th>Almacén (WhsCode)</th>
-      <th>DocNum</th>
-    </tr>
+  <form class="filter" method="get">
+    <label>Desde
+      <input type="date" name="start_date" value="{{ filters.start_date }}">
+    </label>
+    <label>Hasta
+      <input type="date" name="end_date" value="{{ filters.end_date }}">
+    </label>
+    <label>Almacén
+      <input type="text" name="whscode" value="{{ filters.whscode }}">
+    </label>
+    {% if is_admin %}
+    <label>Usuario
+      <input type="text" name="username" value="{{ filters.username }}">
+    </label>
+    {% endif %}
+    <button type="submit">Filtrar</button>
+  </form>
+  <div class="table-wrapper">
+  <table class="history-table">
+    <thead>
+      <tr>
+        <th>Fecha / Hora</th>
+        <th>Usuario</th>
+        <th>Cliente (CardCode)</th>
+        <th>Almacén</th>
+        <th>DocNum</th>
+        <th>Artículo</th>
+        <th>Cantidad</th>
+      </tr>
+    </thead>
+    <tbody>
     {% for r in rows %}
-    <tr>
-      <td>{{ r['timestamp'] }}</td>
-      <td>{{ r['cardcode'] }}</td>
-      <td>{{ r['whscode'] }}</td>
-      <td>{{ r['docnum'] }}</td>
-    </tr>
+      <tr>
+        <td>{{ r['timestamp'] }}</td>
+        <td>{{ r['username'] }}</td>
+        <td>{{ r['cardcode'] }}</td>
+        <td>{{ r['whscode'] }}</td>
+        <td>{{ r['docnum'] }}</td>
+        <td>{{ r['itemcode'] }}</td>
+        <td>{{ r['quantity'] }}</td>
+      </tr>
     {% endfor %}
     {% if not rows %}
-    <tr>
-      <td colspan="4">No hay órdenes registradas aún.</td>
-    </tr>
+      <tr>
+        <td colspan="7">No hay órdenes registradas aún.</td>
+      </tr>
     {% endif %}
+    </tbody>
   </table>
+  </div>
   <p><a href="{{ url_for('logout') }}">Cerrar sesión</a></p>
 </body>
-
 </html>


### PR DESCRIPTION
## Summary
- record each item line when saving orders
- add filters and per-line details in history view
- style history page for better readability

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68af5701635c8322aa9c6f4740ac84fe