### PR TITLE
Format timestamps and enhance history filters

### DIFF
--- a/app.py
+++ b/app.py
@@ -295,13 +295,11 @@ def history():
         return redirect(url_for('login'))
     start_date = request.args.get('start_date')
     end_date = request.args.get('end_date')
-    codex/update-order-history-view-format-zxh0vb
     whscode = request.args.getlist('whscode')
     user_filter = request.args.getlist('username')
 
-main
     conn = get_db_connection(); cur = conn.cursor()
-    allowed = ('manager','admin','supervisor')
+    allowed = ('manager', 'admin', 'supervisor')
     query = (
         "SELECT timestamp, username, cardcode, whscode, docnum, itemcode, quantity "
         "FROM recorded_orders WHERE 1=1"
@@ -309,9 +307,7 @@ main
     params = []
     if session.get('role') in allowed:
         if user_filter:
-    codex/update-order-history-view-format-zxh0vb
             query += " AND username = ANY(%s)"
-main
             params.append(user_filter)
     else:
         query += " AND username=%s"
@@ -323,12 +319,13 @@ main
         query += " AND timestamp::date <= %s"
         params.append(end_date)
     if whscode:
-   codex/update-order-history-view-format-zxh0vb
         query += " AND whscode = ANY(%s)"
         params.append(whscode)
     query += " ORDER BY timestamp DESC LIMIT 100"
     cur.execute(query, params)
-    rows = cur.fetchall()
+    rows = [dict(r) for r in cur.fetchall()]
+    for r in rows:
+        r['timestamp'] = r['timestamp'].strftime('%d/%m/%Y %H:%M:%S')
     cur.execute("SELECT whscode FROM warehouses ORDER BY whscode")
     warehouses = [r['whscode'] for r in cur.fetchall()]
     users_options = []
@@ -337,9 +334,14 @@ main
         users_options = [r['username'] for r in cur.fetchall()]
     cur.close(); conn.close()
     filters = {'start_date': start_date, 'end_date': end_date, 'whscode': whscode, 'username': user_filter}
-    return render_template('history.html', rows=rows, filters=filters, is_admin=session.get('role') in allowed,
-                           warehouses=warehouses, users_options=users_options)
-main
+    return render_template(
+        'history.html',
+        rows=rows,
+        filters=filters,
+        is_admin=session.get('role') in allowed,
+        warehouses=warehouses,
+        users_options=users_options,
+    )
 
 @app.route("/admin", methods=["GET", "POST"])
 @roles_required('admin')

--- a/templates/history.html
+++ b/templates/history.html
@@ -16,7 +16,6 @@
       <input type="date" name="end_date" value="{{ filters.end_date }}">
     </label>
     <label>Almacén
-codex/update-order-history-view-format-zxh0vb
       <select name="whscode" multiple>
         {% for wh in warehouses %}
         <option value="{{ wh }}" {% if wh in filters.whscode %}selected{% endif %}>{{ wh }}</option>
@@ -30,7 +29,6 @@ codex/update-order-history-view-format-zxh0vb
         <option value="{{ u }}" {% if u in filters.username %}selected{% endif %}>{{ u }}</option>
         {% endfor %}
       </select>
-main
     </label>
     {% endif %}
     <button type="submit">Filtrar</button>
@@ -43,9 +41,7 @@ main
         <th>Usuario</th>
         <th>Cliente (CardCode)</th>
         <th>Almacén</th>
-codex/update-order-history-view-format-zxh0vb
         <th>Doc SAP</th>
-main
         <th>Artículo</th>
         <th>Cantidad</th>
       </tr>
@@ -53,9 +49,7 @@ main
     <tbody>
     {% for r in rows %}
       <tr>
-codex/update-order-history-view-format-zxh0vb
-        <td>{{ r['timestamp'].strftime('%d/%m/%Y %H:%M:%S') }}</td>
-main
+        <td>{{ r['timestamp'] }}</td>
         <td>{{ r['username'] }}</td>
         <td>{{ r['cardcode'] }}</td>
         <td>{{ r['whscode'] }}</td>

--- a/templates/result.html
+++ b/templates/result.html
@@ -93,9 +93,9 @@
 
 <body>
   {% if success %}
-  <h2>✅ Orden creada con éxito</h2>
-  <p><strong>Número de documento (DocNum):</strong> {{ docnum }}</p>
-  <p><small>(ID interno DocEntry: {{ docentry }})</small></p>
+    <h2>✅ Orden creada con éxito</h2>
+    <p><strong>Doc SAP:</strong> {{ docnum }}</p>
+    <p><small>(ID interno DocEntry: {{ docentry }})</small></p>
   {% else %}
   <h2>❌ Error al crear la orden</h2>
   <pre>{{ error }}</pre>


### PR DESCRIPTION
## Summary
- Format order timestamps as `DD/MM/YYYY HH:mm:ss`
- Replace warehouse and user filters with multi-select dropdowns
- Rename DocNum column and labels to "Doc SAP"

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68afaea052b08322908bea424af2b961