### PR TITLE
Remove unused pricing fields from admin portal

### DIFF
--- a/models/item_warehouse.py
+++ b/models/item_warehouse.py
@@ -13,6 +13,4 @@ class ItemWarehouse(db.Model):
         db.ForeignKey("warehouses.whscode", onupdate="CASCADE", ondelete="RESTRICT"),
         primary_key=True,
     )
-    price = db.Column(db.Numeric(12, 2))
-    min_stock = db.Column(db.Integer)
     item = db.relationship("Item", back_populates="warehouses")

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -102,7 +102,7 @@
       <td>{{ i.description }}</td>
       <td>
         {% for w in i.warehouses %}
-          {{ w.whscode }} ({{ w.price }} / {{ w.min_stock }}){% if not loop.last %}, {% endif %}
+          {{ w.whscode }}{% if not loop.last %}, {% endif %}
         {% endfor %}
       </td>
       <td>
@@ -129,8 +129,6 @@
     <input type="hidden" name="form_type" value="assign_item_wh">
     ItemCode: <input type="text" name="itemcode" required>
     WhsCode: <input type="text" name="whscode" required>
-    Precio: <input type="number" step="0.01" name="price">
-    Stock Mínimo: <input type="number" name="min_stock">
     <button type="submit">Guardar</button>
   </form>
 
@@ -143,4 +141,3 @@
   </form>
 </body>
 </html>
-templates/history.html


### PR DESCRIPTION
## Summary
- drop price and min_stock management from item-warehouse relations
- clean admin template and remove stray history link
- simplify item endpoints to only return warehouse codes

## Testing
- `python -m py_compile app.py models/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0af964a488322a1b1cb476e53a476