### PR TITLE
Actualizar selección de almacenes y menús

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -1,19 +1,104 @@
 // static/js/dashboard.js
 
 document.addEventListener('DOMContentLoaded', () => {
-  const table  = document.getElementById('lines');
+  const table = document.getElementById('lines');
   const addBtn = document.getElementById('addLine');
+  const whSelect = document.getElementById('warehouse');
+  const cardcodeContainer = document.getElementById('cardcode-container');
+  const dataTag = document.getElementById('warehousesData');
+  const warehousesData = dataTag ? JSON.parse(dataTag.textContent) : {};
 
-  // Clonar línea
+  let currentItems = [];
+
+  function fillItemSelect(sel) {
+    sel.innerHTML = '<option value="" disabled selected>Selecciona un menú…</option>';
+    currentItems.forEach(it => {
+      const opt = document.createElement('option');
+      opt.value = it.itemcode;
+      opt.textContent = it.description;
+      sel.appendChild(opt);
+    });
+    if (currentItems.length === 0) {
+      sel.disabled = true;
+    } else {
+      sel.disabled = false;
+      sel.removeAttribute('disabled');
+    }
+  }
+
+  function updateItemSelects() {
+    table.querySelectorAll('select[name="item_code"]').forEach(fillItemSelect);
+  }
+
+  function loadItems(whscode) {
+    fetch(`/warehouses/${encodeURIComponent(whscode)}/items`)
+      .then(r => {
+        if (!r.ok) throw new Error('No se pudo cargar items');
+        return r.json();
+      })
+      .then(data => {
+        currentItems = data;
+        updateItemSelects();
+      })
+      .catch(err => console.error(err));
+  }
+
+  function renderCardcode(whscode) {
+    const options = warehousesData[whscode] || [];
+    cardcodeContainer.innerHTML = '';
+    if (options.length > 1) {
+      const select = document.createElement('select');
+      select.name = 'cardcode';
+      select.id = 'cardcode';
+      select.required = true;
+      const placeholder = document.createElement('option');
+      placeholder.value = '';
+      placeholder.disabled = true;
+      placeholder.selected = true;
+      placeholder.textContent = 'Selecciona descripción…';
+      select.appendChild(placeholder);
+      options.forEach(o => {
+        const opt = document.createElement('option');
+        opt.value = o.cardcode;
+        opt.textContent = o.whsdesc;
+        select.appendChild(opt);
+      });
+      cardcodeContainer.appendChild(select);
+    } else if (options.length === 1) {
+      const input = document.createElement('input');
+      input.type = 'hidden';
+      input.name = 'cardcode';
+      input.value = options[0].cardcode;
+      cardcodeContainer.appendChild(input);
+      const strong = document.createElement('strong');
+      strong.textContent = options[0].whsdesc;
+      cardcodeContainer.appendChild(strong);
+    }
+  }
+
+  if (whSelect) {
+    whSelect.addEventListener('change', e => {
+      const wh = e.target.value;
+      renderCardcode(wh);
+      loadItems(wh);
+    });
+
+    if (whSelect.tagName !== 'SELECT') {
+      const wh = whSelect.value;
+      renderCardcode(wh);
+      loadItems(wh);
+    }
+  }
+
   addBtn.addEventListener('click', () => {
     const first = table.querySelector('.line');
     const clone = first.cloneNode(true);
     clone.querySelector('input[name="quantity"]').value = '';
-    clone.querySelector('select[name="item_code"]').selectedIndex = 0;
+    const sel = clone.querySelector('select[name="item_code"]');
+    fillItemSelect(sel);
     table.appendChild(clone);
   });
 
-  // Eliminar línea (dejando al menos una)
   table.addEventListener('click', e => {
     if (e.target.classList.contains('remove')) {
       const rows = table.querySelectorAll('.line');
@@ -23,3 +108,4 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 });
+

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -134,19 +134,21 @@
 
       <!-- WAREHOUSE: Selección de almacén según sesión -->
       <label>Almacén:<br>
-        {% if warehouses|length > 1 %}
+        {% set wh_list = warehouses.keys()|list %}
+        {% if wh_list|length > 1 %}
           <select name="warehouse" id="warehouse" required>
             <option value="" disabled selected>Selecciona un almacén…</option>
-            {% for wh in warehouses %}
+            {% for wh in wh_list %}
               <option value="{{ wh }}">{{ wh }}</option>
             {% endfor %}
           </select>
         {% else %}
           {# Si sólo hay uno, ocultamos el select y enviamos valor fijo #}
-          <input type="hidden" name="warehouse" value="{{ warehouses[0] or '' }}">
-          <strong>{{ warehouses[0] or '—' }}</strong>
+          <input type="hidden" name="warehouse" id="warehouse" value="{{ wh_list[0] or '' }}">
+          <strong>{{ wh_list[0] or '—' }}</strong>
         {% endif %}
       </label>
+      <div id="cardcode-container"></div>
       <br><br>
       
       <table id="lines">
@@ -157,13 +159,8 @@
         </tr>
         <tr class="line">
           <td>
-            <select name="item_code" required>
+            <select name="item_code" required disabled>
               <option value="" disabled selected>Selecciona un menú…</option>
-              {% for item in items %}
-              <option value="{{ item['itemcode'] }}">
-                {{ item['description'] }}
-              </option>
-              {% endfor %}
             </select>
           </td>
           <td>
@@ -190,33 +187,7 @@
     </p>
 
 
-    <script>
-      document.addEventListener('DOMContentLoaded', () => {
-        const table = document.getElementById('lines');
-        const addBtn = document.getElementById('addLine');
-        console.log('table:', table, 'addBtn:', addBtn);
-
-        if (!table || !addBtn) {
-          console.error('No se encontró #lines o #addLine en el DOM');
-          return;
-        }
-
-        addBtn.addEventListener('click', () => {
-          const first = table.querySelector('.line');
-          console.log('clonando línea:', first);
-          if (!first) {
-            console.error('No se encontró ninguna fila .line para clonar');
-            return;
-          }
-          const clone = first.cloneNode(true);
-          clone.querySelector('input[name="quantity"]').value = '';
-          clone.querySelector('select[name="item_code"]').selectedIndex = 0;
-          table.appendChild(clone);
-        });
-      });
-    </script>
-
-
+    <script id="warehousesData" type="application/json">{{ warehouses | tojson }}</script>
     <script src="{{ url_for('static', filename='js/dashboard.js') }}"></script>
   </body>
 


### PR DESCRIPTION
## Resumen
- Evitar bloqueo por CSP moviendo datos de almacenes a una etiqueta JSON consumida desde JavaScript.
- Habilitar el selector de menús al cargar ítems y quitar la marca de deshabilitado.

## Pruebas
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1dc25d18c8322a064c0d1de05ebf1