### PR TITLE
Fix food menu dropdown on dashboard

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -16,7 +16,13 @@ document.addEventListener('DOMContentLoaded', () => {
       opt.textContent = it.description;
       sel.appendChild(opt);
     });
-    sel.disabled = currentItems.length === 0;
+
+    if (currentItems.length > 0) {
+      sel.disabled = false;
+      sel.removeAttribute('disabled');
+    } else {
+      sel.disabled = true;
+    }
   }
 
   function updateItemSelects() {

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -157,13 +157,13 @@
           <th>Cantidad</th>
           <th>Acción</th>
         </tr>
-        <tr class="line">
-          <td>
-            <select name="item_code" required disabled>
-              <option value="" disabled selected>Selecciona un menú…</option>
-            </select>
-          </td>
-          <td>
+          <tr class="line">
+            <td>
+              <select name="item_code" required>
+                <option value="" disabled selected>Selecciona un menú…</option>
+              </select>
+            </td>
+            <td>
             <input type="number" name="quantity" min="1" required
               oninvalid="this.setCustomValidity('Introduce una cantidad mayor a cero')"
               oninput="this.setCustomValidity('')" />


### PR DESCRIPTION
## Summary
- Enable menu selection by default and fill options once items load
- Clean up dashboard template so menu select isn't permanently disabled

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1fd422a0c8322b74a69b844a9114d