### PR TITLE
Load items when warehouse preselected

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -76,17 +76,18 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   if (whSelect) {
-    whSelect.addEventListener('change', e => {
-      const wh = e.target.value;
-      renderCardcode(wh);
-      loadItems(wh);
-    });
-
-    if (whSelect.tagName !== 'SELECT') {
+    const handleWhChange = () => {
       const wh = whSelect.value;
-      renderCardcode(wh);
-      loadItems(wh);
-    }
+      if (wh) {
+        renderCardcode(wh);
+        loadItems(wh);
+      }
+    };
+
+    whSelect.addEventListener('change', handleWhChange);
+
+    // Cargar items iniciales si el almacén ya está preseleccionado
+    handleWhChange();
   }
 
   addBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Load warehouse items on initial page render by triggering handler if warehouse already selected

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b22d4e29108322816ed646346c23ea