### PR TITLE
Redirect logged-in users from root to dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -157,7 +157,10 @@ def refresh_user_warehouses():
 
 # Rutas de la aplicación
 @app.route("/")
+
 def index():
+    if "username" in session:
+        return redirect(url_for("dashboard"))
     return redirect(url_for("login"))
 
 @app.route("/login", methods=["GET", "POST"])


### PR DESCRIPTION
## Summary
- Redirect `/` to dashboard when session is active instead of always going to login

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b34d5d164c8322860e884be2784c7b