### PR TITLE
Handle multiple warehouse descriptions

### DIFF
--- a/app.py
+++ b/app.py
@@ -148,10 +148,10 @@ def refresh_user_warehouses():
     warehouses = {}
     for r in rows:
         wh = r['whscode'].strip()
-        warehouses.setdefault(wh, []).append({
-            'cardcode': r['cardcode'].strip(),
-            'whsdesc': r['whsdesc']
-        })
+        cardcodes = [c.strip() for c in r['cardcode'].split(',')]
+        whsdescs = [d.strip() for d in r['whsdesc'].split(',')]
+        for cc, desc in zip(cardcodes, whsdescs):
+            warehouses.setdefault(wh, []).append({'cardcode': cc, 'whsdesc': desc})
     session['warehouses'] = list(warehouses.keys())
     session['warehouse_cards'] = warehouses
 


### PR DESCRIPTION
## Summary
- Split comma-separated CardCode and WhsDesc values per warehouse so the dashboard can present a dropdown of descriptions when several codes map to one warehouse

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b35131434083229efe65fd1a2ab9dc